### PR TITLE
Add Python compatibility workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -161,7 +161,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build_core
@@ -245,7 +245,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push - BroAPT-App image
         id: docker_build_app

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -1,0 +1,57 @@
+name: "Python Compatibility"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 4 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        experimental:
+          - false
+        include:
+          - python-version: "3.15"
+            experimental: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ matrix.experimental }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install Flask file-magic pandas PyYAML requests
+
+      - name: Verify source compatibility
+        run: |
+          python -m compileall -q \
+            source/client/python \
+            source/server/python \
+            cluster/app/source/python \
+            cluster/core/source/python \
+            cluster/daemon/python
+          python -c 'import flask, magic, pandas, requests, yaml; print("imports ok")'

--- a/.github/workflows/python-compatibility.yml
+++ b/.github/workflows/python-compatibility.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install Flask file-magic pandas PyYAML requests
+          python -m pip install Flask PyYAML requests
+
+      - name: Install stable dependencies
+        if: ${{ !matrix.experimental }}
+        run: python -m pip install file-magic pandas
 
       - name: Verify source compatibility
         run: |
@@ -54,4 +58,8 @@ jobs:
             cluster/app/source/python \
             cluster/core/source/python \
             cluster/daemon/python
-          python -c 'import flask, magic, pandas, requests, yaml; print("imports ok")'
+          python -c 'import flask, requests, yaml; print("base imports ok")'
+
+      - name: Verify stable imports
+        if: ${{ !matrix.experimental }}
+        run: python -c 'import magic, pandas; print("stable imports ok")'


### PR DESCRIPTION
## Summary
- add Python 3.10-3.14 compatibility checks with experimental Python 3.15
- compile all BroAPT Python source trees and verify runtime imports
- use the repository token for GHCR authentication

## Validation
- actionlint
- local Python 3.14 compile/import smoke test